### PR TITLE
added GPU support for FFMPEG

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,21 +2,10 @@
 FROM node:20
 
 # Install ffmpeg with NVIDIA GPU support
-# For GPU support, ffmpeg needs to be compiled with NVENC/NVDEC support
-# or use a pre-built version with NVIDIA support
 RUN apt-get update && \
     apt-get install -y \
     ffmpeg \
     && rm -rf /var/lib/apt/lists/*
-
-# Note: For full NVIDIA GPU support, you may need to build ffmpeg from source
-# with --enable-cuda-nvcc --enable-cuvid --enable-nvenc --enable-nonfree
-# or use a pre-built image like nvidia/cuda with ffmpeg compiled with GPU support
-# Uncomment below to install additional NVIDIA libraries if needed:
-# RUN apt-get update && apt-get install -y \
-#     libnvidia-encode-* \
-#     libnvidia-decode-* \
-#     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,22 @@
 # Backend Dockerfile
 FROM node:20
 
-# Install ffmpeg
-RUN apt-get update && apt-get install -y ffmpeg
+# Install ffmpeg with NVIDIA GPU support
+# For GPU support, ffmpeg needs to be compiled with NVENC/NVDEC support
+# or use a pre-built version with NVIDIA support
+RUN apt-get update && \
+    apt-get install -y \
+    ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Note: For full NVIDIA GPU support, you may need to build ffmpeg from source
+# with --enable-cuda-nvcc --enable-cuvid --enable-nvenc --enable-nonfree
+# or use a pre-built image like nvidia/cuda with ffmpeg compiled with GPU support
+# Uncomment below to install additional NVIDIA libraries if needed:
+# RUN apt-get update && apt-get install -y \
+#     libnvidia-encode-* \
+#     libnvidia-decode-* \
+#     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -69,6 +69,8 @@ const server = app.listen(PORT, async () => {
   PlaylistUpdater.registerChannelsPlaylist(ChannelService.getChannels());
 });
 
+// Increase server timeout to 90 seconds for large playlist requests
+server.timeout = 90000;
 
 // Web Sockets with explicit CORS configuration
 const io = new Server(server, {
@@ -78,6 +80,9 @@ const io = new Server(server, {
     allowedHeaders: ["Authorization", "Content-Type"],
     credentials: true,
   },
+  // Increase ping timeout to prevent disconnection during large playlist loading
+  pingTimeout: 90000,
+  pingInterval: 25000,
 });
 
 // Add JWT authentication middleware to socket.io

--- a/backend/services/PlaylistService.js
+++ b/backend/services/PlaylistService.js
@@ -11,8 +11,16 @@ class PlaylistService {
 
         let content = "";
         if(playlist.startsWith("http")) {
-            const response = await fetch(playlist);
-            content = await response.text();
+            // Set timeout to 90 seconds for large playlists
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 90000);
+            
+            try {
+                const response = await fetch(playlist, { signal: controller.signal });
+                content = await response.text();
+            } finally {
+                clearTimeout(timeoutId);
+            }
 
             //check for streamedSu here and add channel for every source
             if(playlist.includes('streamed.su')) {

--- a/backend/services/session/StreamedSuSession.js
+++ b/backend/services/session/StreamedSuSession.js
@@ -14,12 +14,20 @@ class StreamedSuSession extends SessionHandler {
 
     static async fetchApiChannels(apiUrl, mode, playlistName) {
         try {
-            const response = await fetch(apiUrl);
-            if (!response.ok) {
-                throw new Error(response);
+            // Set timeout to 90 seconds for large API responses
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 90000);
+            
+            let response, data;
+            try {
+                response = await fetch(apiUrl, { signal: controller.signal });
+                if (!response.ok) {
+                    throw new Error(response);
+                }
+                data = await response.json();
+            } finally {
+                clearTimeout(timeoutId);
             }
-
-            const data = await response.json();
 
             let channels = [];
             data.forEach(stream => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,23 @@ services:
       # ADMIN_ENABLED: "true"
       # ADMIN_PASSWORD: "your_secure_password"
       # CHANNEL_SELECTION_REQUIRES_ADMIN: "true"
+
+      # GPU acceleration configuration (NVIDIA)
+      # Set USE_GPU to "true" to enable NVIDIA GPU acceleration
+      # USE_GPU: "true"
+      # GPU_DECODER: "h264_cuvid"  # Options: h264_cuvid, hevc_cuvid, mpeg2_cuvid, vc1_cuvid, vp8_cuvid, vp9_cuvid
+      # GPU_ENCODER: "h264_nvenc"  # Options: h264_nvenc, hevc_nvenc
+    
+    # Uncomment the following lines to enable NVIDIA GPU support
+    # Requires nvidia-docker2 or Docker with NVIDIA Container Runtime installed
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: 1
+    #           capabilities: [gpu]
+    
     networks:
       - app-network
 


### PR DESCRIPTION
PR for [this issue](https://github.com/antebrl/IPTV-Restream/issues/75)
I had to pump up the stream creation process a little bit. 
It worked on my streams quite nice but please test it thoroughly: I am not an ffmpeg expert. 
It is focused on nvidia GPUs because that's what I can test but adapting the docker-compose file and the GPU_decoder/encoder variables other GPUs should be possible to use as well.
